### PR TITLE
Fix for https://github.com/rlovtangen/grails-wkhtmltopdf/issues/6. 

### DIFF
--- a/WkhtmltopdfGrailsPlugin.groovy
+++ b/WkhtmltopdfGrailsPlugin.groovy
@@ -35,7 +35,8 @@ class WkhtmltopdfGrailsPlugin {
     private void replaceRenderMethod(controllerClass, ctx) {
         def oldRender = controllerClass.metaClass.pickMethod("render", [Map] as Class[])
         controllerClass.metaClass.render = { Map params ->
-            if (params.contentType?.toLowerCase() == 'application/pdf' || response.format == "pdf") {
+            // if the "file" parameter is provided then we assume the user wants to render an existing file. I.e. render(file: new File(absolutePath), fileName: "book.pdf")
+            if ((params.contentType?.toLowerCase() == 'application/pdf' || response.format == "pdf") && (!params.file)) {
                 def filename = params.remove("filename")
 
                 def data = ctx.wkhtmltoxService.makePdf(params)

--- a/grails-app/services/org/wkhtmltox/WkhtmltoxService.groovy
+++ b/grails-app/services/org/wkhtmltox/WkhtmltoxService.groovy
@@ -43,11 +43,12 @@ class WkhtmltoxService {
 
         if (headerPartial) {
             File headerFile = makePartialViewFile(headerPartial)
-            wrapper.headerHtml = "file://" + headerFile.absolutePath
+            //We don't need "file://" prefix. See https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1645.  It doesn't work on windows
+            wrapper.headerHtml = headerFile.absolutePath
         }
         if (footerPartial) {
             File footerFile = makePartialViewFile(footerPartial)
-            wrapper.footerHtml = "file://" + footerFile.absolutePath
+            wrapper.footerHtml = footerFile.absolutePath
         }
 
         def wkhtmltoxConfig = grailsApplication.mergedConfig.grails.plugin.wkhtmltox

--- a/src/groovy/org/wkhtmltox/WkhtmltoxExecutor.groovy
+++ b/src/groovy/org/wkhtmltox/WkhtmltoxExecutor.groovy
@@ -1,8 +1,11 @@
 package org.wkhtmltox
 
+import groovy.util.logging.Commons
+
 /**
  * @author tobiasnendel
  */
+@Commons
 class WkhtmltoxExecutor {
 
     String binaryPath
@@ -32,8 +35,15 @@ class WkhtmltoxExecutor {
             def commandList = wrapper.toArgumentsList()
             commandList.add(0, binaryPath)
             commandList << "-q" << "-" << "-"
-            def process = (commandList as String[]).execute()
 
+
+            if (log.isDebugEnabled()){
+                log.debug("Invoking wkhtml2pdf with command $commandList")
+            }
+            if (log.isTraceEnabled()){
+                log.debug "Following html will be converted to PDF: $html"
+            }
+            def process = (commandList as String[]).execute()
             def stdout = new ByteArrayOutputStream()
             stderr = new ByteArrayOutputStream()
             OutputStreamWriter os = new OutputStreamWriter(process.outputStream, "UTF8")

--- a/src/groovy/org/wkhtmltox/WkhtmltoxExecutor.groovy
+++ b/src/groovy/org/wkhtmltox/WkhtmltoxExecutor.groovy
@@ -36,13 +36,9 @@ class WkhtmltoxExecutor {
             commandList.add(0, binaryPath)
             commandList << "-q" << "-" << "-"
 
+            log.debug("Invoking wkhtml2pdf with command $commandList")
+            log.trace "Following html will be converted to PDF: $html"
 
-            if (log.isDebugEnabled()){
-                log.debug("Invoking wkhtml2pdf with command $commandList")
-            }
-            if (log.isTraceEnabled()){
-                log.debug "Following html will be converted to PDF: $html"
-            }
             def process = (commandList as String[]).execute()
             def stdout = new ByteArrayOutputStream()
             stderr = new ByteArrayOutputStream()


### PR DESCRIPTION
header & footer were not working on windows due to "file://" prefix. Changes tested on windows 10 64bit, debian 7.5, wkhtmltopdf 0.12.2.4

 Also, added extra logging to see the generated html and command line options
